### PR TITLE
fix: onOrder buttons should be selectable by hitting the 'Space' key

### DIFF
--- a/src/js/components/List/List.js
+++ b/src/js/components/List/List.js
@@ -1,4 +1,11 @@
-import React, { Fragment, useContext, useMemo, useRef, useState } from 'react';
+import React, {
+  Fragment,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import styled, { ThemeContext } from 'styled-components';
 
 import { DataContext } from '../../contexts/DataContext';
@@ -249,54 +256,60 @@ const List = React.forwardRef(
       ariaProps['aria-activedescendant'] = activeId;
     }
 
+    const onSelectOption = useCallback(
+      (event) => {
+        if ((onClickItem || onOrder) && active >= 0) {
+          if (onOrder) {
+            const index = Math.trunc(active / 2);
+            // Call onOrder with the re-ordered data.
+            // Update the active control index so that the
+            // active control will stay on the same item
+            // even though it moved up or down.
+            const newIndex = active % 2 ? index + 1 : index - 1;
+            onOrder(reorder(orderableData, pinnedInfo, index, newIndex));
+            updateActive(
+              active % 2
+                ? Math.min(active + 2, orderableData.length * 2 - 2)
+                : Math.max(active - 2, 1),
+            );
+          } else if (
+            disabledItems?.includes(getValue(data[active], active, itemKey))
+          ) {
+            event.preventDefault();
+          } else if (onClickItem) {
+            event.persist();
+            const adjustedEvent = event;
+            adjustedEvent.item = data[active];
+            adjustedEvent.index = active;
+            onClickItem(adjustedEvent);
+            sendAnalytics({
+              type: 'listItemClick',
+              element: listRef.current,
+              event: adjustedEvent,
+              item: data[active],
+              index: active,
+            });
+          }
+        }
+      },
+      [
+        active,
+        onOrder,
+        orderableData,
+        pinnedInfo,
+        disabledItems,
+        data,
+        itemKey,
+        onClickItem,
+        updateActive,
+      ],
+    );
+
     return (
       <Container {...containterProps}>
         <Keyboard
-          onEnter={
-            (onClickItem || onOrder) && active >= 0
-              ? (event) => {
-                  if (onOrder) {
-                    const index = Math.trunc(active / 2);
-                    // Call onOrder with the re-ordered data.
-                    // Update the active control index so that the
-                    // active control will stay on the same item
-                    // even though it moved up or down.
-                    if (active % 2) {
-                      onOrder(
-                        reorder(orderableData, pinnedInfo, index, index + 1),
-                      );
-                      updateActive(
-                        Math.min(active + 2, orderableData.length * 2 - 2),
-                      );
-                    } else {
-                      onOrder(
-                        reorder(orderableData, pinnedInfo, index, index - 1),
-                      );
-                      updateActive(Math.max(active - 2, 1));
-                    }
-                  } else if (
-                    disabledItems?.includes(
-                      getValue(data[active], active, itemKey),
-                    )
-                  ) {
-                    event.preventDefault();
-                  } else if (onClickItem) {
-                    event.persist();
-                    const adjustedEvent = event;
-                    adjustedEvent.item = data[active];
-                    adjustedEvent.index = active;
-                    onClickItem(adjustedEvent);
-                    sendAnalytics({
-                      type: 'listItemClick',
-                      element: listRef.current,
-                      event: adjustedEvent,
-                      item: data[active],
-                      index: active,
-                    });
-                  }
-                }
-              : undefined
-          }
+          onEnter={onSelectOption}
+          onSpace={onSelectOption}
           onUp={
             (onClickItem || onOrder) && active
               ? () => {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
fix: onOrder buttons should be selectable by hitting the 'Space' key

#### Where should the reviewer start?
List Component

#### What testing has been done on this PR?
1. Manually clicking the start icon to ensure the expected behavior and set default value.
2. Local Jest tests.

#### How should this be manually tested?
1. Run storybook and open List Component section
2. Select Order section Test with Enter and Space

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?
No
#### What are the relevant issues?
fixes: #7131
#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
No
