### PR TITLE
fix: focus indicator for Layer's hidden anchor in Firefox

### DIFF
--- a/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
+++ b/src/js/components/DataFilters/__tests__/__snapshots__/DataFilters-test.tsx.snap
@@ -1816,6 +1816,10 @@ exports[`DataFilters layer 2`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
 
 }

--- a/src/js/components/Layer/LayerContainer.js
+++ b/src/js/components/Layer/LayerContainer.js
@@ -28,6 +28,9 @@ const HiddenAnchor = styled.a`
   height: 0;
   overflow: hidden;
   position: absolute;
+  &:focus {
+    outline: none;
+  }
 `;
 
 const LayerContainer = forwardRef(
@@ -310,8 +313,9 @@ const LayerContainer = forwardRef(
           // restricting scroll could inhibit the user's
           // ability to scroll the page while the layer is open.
           restrictScroll={
-            !layerTarget &&
-            (modal || hitResponsiveBreakpoint) ? true : undefined
+            !layerTarget && (modal || hitResponsiveBreakpoint)
+              ? true
+              : undefined
           }
           trapFocus
         >

--- a/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
+++ b/src/js/components/Layer/__tests__/__snapshots__/Layer-test.js.snap
@@ -67,6 +67,10 @@ exports[`Layer animation fadeIn 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -224,6 +228,10 @@ exports[`Layer animation false 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -387,6 +395,10 @@ exports[`Layer animation slide 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -548,6 +560,10 @@ exports[`Layer animation true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -707,6 +723,10 @@ exports[`Layer custom margin 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -871,6 +891,10 @@ exports[`Layer custom theme 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -1027,6 +1051,10 @@ exports[`Layer dark context 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -1147,6 +1175,10 @@ exports[`Layer focus on layer 1`] = `
   position: absolute;
 }
 
+.c1:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -1239,6 +1271,10 @@ exports[`Layer hidden 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c1 {
     position: relative;
@@ -1321,7 +1357,7 @@ exports[`Layer hidden 3`] = `
   >
     <a
       aria-hidden="true"
-      class="LayerContainer__HiddenAnchor-sc-1srj14c-0 IjFXP"
+      class="LayerContainer__HiddenAnchor-sc-1srj14c-0 bCWUGW"
       tabindex="-1"
     />
     This is a layer
@@ -1432,6 +1468,10 @@ exports[`Layer invoke onClickOutside when modal={false} 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c2:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -1584,6 +1624,10 @@ exports[`Layer invoke onClickOutside when modal={false} and layer has target 1`]
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c1 {
     position: relative;
@@ -1705,6 +1749,10 @@ exports[`Layer invoke onClickOutside when modal={true} 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -1869,6 +1917,10 @@ exports[`Layer invoke onClickOutside when modal={true} and layer has target 1`] 
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -2208,6 +2260,10 @@ exports[`Layer invokes onEsc when modal={false} 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c10 {
     margin-left: 6px;
@@ -2481,6 +2537,10 @@ exports[`Layer margin large 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -2640,6 +2700,10 @@ exports[`Layer margin medium 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -2803,6 +2867,10 @@ exports[`Layer margin none 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -2962,6 +3030,10 @@ exports[`Layer margin small 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -3125,6 +3197,10 @@ exports[`Layer margin xsmall 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -3281,6 +3357,10 @@ exports[`Layer non-modal 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -3401,6 +3481,10 @@ exports[`Layer not steal focus from an autofocus focusable element 1`] = `
   position: absolute;
 }
 
+.c1:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
 
 }
@@ -3502,6 +3586,10 @@ exports[`Layer plain 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -3665,6 +3753,10 @@ exports[`Layer position: bottom - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -3825,6 +3917,10 @@ exports[`Layer position: bottom - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -3990,6 +4086,10 @@ exports[`Layer position: bottom - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -4150,6 +4250,10 @@ exports[`Layer position: bottom - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -4313,6 +4417,10 @@ exports[`Layer position: bottom-left - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -4473,6 +4581,10 @@ exports[`Layer position: bottom-left - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -4638,6 +4750,10 @@ exports[`Layer position: bottom-left - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -4798,6 +4914,10 @@ exports[`Layer position: bottom-left - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -4961,6 +5081,10 @@ exports[`Layer position: bottom-right - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -5121,6 +5245,10 @@ exports[`Layer position: bottom-right - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -5286,6 +5414,10 @@ exports[`Layer position: bottom-right - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -5448,6 +5580,10 @@ exports[`Layer position: bottom-right - full: vertical 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -5607,6 +5743,10 @@ exports[`Layer position: center - full: false 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -5771,6 +5911,10 @@ exports[`Layer position: center - full: horizontal 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -5929,6 +6073,10 @@ exports[`Layer position: center - full: true 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -6093,6 +6241,10 @@ exports[`Layer position: center - full: vertical 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -6252,6 +6404,10 @@ exports[`Layer position: end - full: false 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -6414,6 +6570,10 @@ exports[`Layer position: end - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -6579,6 +6739,10 @@ exports[`Layer position: end - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -6739,6 +6903,10 @@ exports[`Layer position: end - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -6902,6 +7070,10 @@ exports[`Layer position: left - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -7062,6 +7234,10 @@ exports[`Layer position: left - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -7227,6 +7403,10 @@ exports[`Layer position: left - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -7387,6 +7567,10 @@ exports[`Layer position: left - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -7550,6 +7734,10 @@ exports[`Layer position: right - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -7710,6 +7898,10 @@ exports[`Layer position: right - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -7875,6 +8067,10 @@ exports[`Layer position: right - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -8035,6 +8231,10 @@ exports[`Layer position: right - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -8198,6 +8398,10 @@ exports[`Layer position: start - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -8358,6 +8562,10 @@ exports[`Layer position: start - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -8523,6 +8731,10 @@ exports[`Layer position: start - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -8683,6 +8895,10 @@ exports[`Layer position: start - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -8846,6 +9062,10 @@ exports[`Layer position: top - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -9006,6 +9226,10 @@ exports[`Layer position: top - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -9171,6 +9395,10 @@ exports[`Layer position: top - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -9331,6 +9559,10 @@ exports[`Layer position: top - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -9494,6 +9726,10 @@ exports[`Layer position: top-left - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -9654,6 +9890,10 @@ exports[`Layer position: top-left - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -9819,6 +10059,10 @@ exports[`Layer position: top-left - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -9979,6 +10223,10 @@ exports[`Layer position: top-left - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -10142,6 +10390,10 @@ exports[`Layer position: top-right - full: false 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -10302,6 +10554,10 @@ exports[`Layer position: top-right - full: horizontal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -10467,6 +10723,10 @@ exports[`Layer position: top-right - full: true 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -10627,6 +10887,10 @@ exports[`Layer position: top-right - full: vertical 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -10790,6 +11054,10 @@ exports[`Layer should apply background 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -10947,6 +11215,10 @@ exports[`Layer should only place id on StyledLayer when singleId === true 1`] = 
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -11111,6 +11383,10 @@ exports[`Layer should render correct border radius for position: bottom -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -11273,6 +11549,10 @@ exports[`Layer should render correct border radius for position: bottom -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -11440,6 +11720,10 @@ exports[`Layer should render correct border radius for position: bottom -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -11602,6 +11886,10 @@ exports[`Layer should render correct border radius for position: bottom -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -11767,6 +12055,10 @@ exports[`Layer should render correct border radius for position: bottom-left -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -11929,6 +12221,10 @@ exports[`Layer should render correct border radius for position: bottom-left -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -12096,6 +12392,10 @@ exports[`Layer should render correct border radius for position: bottom-left -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -12258,6 +12558,10 @@ exports[`Layer should render correct border radius for position: bottom-left -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -12423,6 +12727,10 @@ exports[`Layer should render correct border radius for position: bottom-right -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -12585,6 +12893,10 @@ exports[`Layer should render correct border radius for position: bottom-right -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -12752,6 +13064,10 @@ exports[`Layer should render correct border radius for position: bottom-right -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -12916,6 +13232,10 @@ exports[`Layer should render correct border radius for position: bottom-right -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -13077,6 +13397,10 @@ exports[`Layer should render correct border radius for position: center -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -13243,6 +13567,10 @@ exports[`Layer should render correct border radius for position: center -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -13403,6 +13731,10 @@ exports[`Layer should render correct border radius for position: center -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -13567,6 +13899,10 @@ exports[`Layer should render correct border radius for position: center -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -13733,6 +14069,10 @@ exports[`Layer should render correct border radius for position: end -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -13895,6 +14235,10 @@ exports[`Layer should render correct border radius for position: end -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -14062,6 +14406,10 @@ exports[`Layer should render correct border radius for position: end -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -14224,6 +14572,10 @@ exports[`Layer should render correct border radius for position: end -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -14389,6 +14741,10 @@ exports[`Layer should render correct border radius for position: left -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -14551,6 +14907,10 @@ exports[`Layer should render correct border radius for position: left -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -14718,6 +15078,10 @@ exports[`Layer should render correct border radius for position: left -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -14880,6 +15244,10 @@ exports[`Layer should render correct border radius for position: left -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -15045,6 +15413,10 @@ exports[`Layer should render correct border radius for position: right -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -15207,6 +15579,10 @@ exports[`Layer should render correct border radius for position: right -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -15374,6 +15750,10 @@ exports[`Layer should render correct border radius for position: right -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -15536,6 +15916,10 @@ exports[`Layer should render correct border radius for position: right -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -15702,6 +16086,10 @@ exports[`Layer should render correct border radius for position: start -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -15864,6 +16252,10 @@ exports[`Layer should render correct border radius for position: start -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -16029,6 +16421,10 @@ exports[`Layer should render correct border radius for position: start -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -16195,6 +16591,10 @@ exports[`Layer should render correct border radius for position: start -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -16356,6 +16756,10 @@ exports[`Layer should render correct border radius for position: top -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -16522,6 +16926,10 @@ exports[`Layer should render correct border radius for position: top -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -16685,6 +17093,10 @@ exports[`Layer should render correct border radius for position: top -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -16851,6 +17263,10 @@ exports[`Layer should render correct border radius for position: top -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -17012,6 +17428,10 @@ exports[`Layer should render correct border radius for position: top-left -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -17176,6 +17596,10 @@ exports[`Layer should render correct border radius for position: top-left -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -17343,6 +17767,10 @@ exports[`Layer should render correct border radius for position: top-left -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -17505,6 +17933,10 @@ exports[`Layer should render correct border radius for position: top-left -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -17670,6 +18102,10 @@ exports[`Layer should render correct border radius for position: top-right -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -17832,6 +18268,10 @@ exports[`Layer should render correct border radius for position: top-right -
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c3:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {
@@ -17999,6 +18439,10 @@ exports[`Layer should render correct border radius for position: top-right -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -18163,6 +18607,10 @@ exports[`Layer should render correct border radius for position: top-right -
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c0 {
     position: fixed;
@@ -18325,6 +18773,10 @@ exports[`Layer target 1`] = `
   position: absolute;
 }
 
+.c3:focus {
+  outline: none;
+}
+
 @media only screen and (max-width:768px) {
   .c1 {
     position: relative;
@@ -18452,6 +18904,10 @@ exports[`Layer target not modal 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c2:focus {
+  outline: none;
 }
 
 @media only screen and (max-width:768px) {

--- a/src/js/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
+++ b/src/js/components/Notification/__tests__/__snapshots__/Notification-test.js.snap
@@ -856,6 +856,10 @@ exports[`Notification position bottom 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 .c9 {
   margin: 0px;
   font-size: 18px;
@@ -1155,6 +1159,10 @@ exports[`Notification position bottom-left 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c2:focus {
+  outline: none;
 }
 
 .c9 {
@@ -1458,6 +1466,10 @@ exports[`Notification position bottom-right 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 .c9 {
   margin: 0px;
   font-size: 18px;
@@ -1757,6 +1769,10 @@ exports[`Notification position center 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c2:focus {
+  outline: none;
 }
 
 .c9 {
@@ -2060,6 +2076,10 @@ exports[`Notification position end 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 .c9 {
   margin: 0px;
   font-size: 18px;
@@ -2359,6 +2379,10 @@ exports[`Notification position left 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c2:focus {
+  outline: none;
 }
 
 .c9 {
@@ -2662,6 +2686,10 @@ exports[`Notification position right 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 .c9 {
   margin: 0px;
   font-size: 18px;
@@ -2961,6 +2989,10 @@ exports[`Notification position start 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c2:focus {
+  outline: none;
 }
 
 .c9 {
@@ -3264,6 +3296,10 @@ exports[`Notification position top 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 .c9 {
   margin: 0px;
   font-size: 18px;
@@ -3565,6 +3601,10 @@ exports[`Notification position top-left 1`] = `
   position: absolute;
 }
 
+.c2:focus {
+  outline: none;
+}
+
 .c9 {
   margin: 0px;
   font-size: 18px;
@@ -3864,6 +3904,10 @@ exports[`Notification position top-right 1`] = `
   height: 0;
   overflow: hidden;
   position: absolute;
+}
+
+.c2:focus {
+  outline: none;
 }
 
 .c9 {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Do Jest tests follow these best practices?

- [ ] `screen` is used for querying.
- [ ] The correct query is used. (Refer to [this list of queries](https://testing-library.com/docs/queries/about/#priority))
- [ ] `asFragment()` is used for snapshot testing.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
